### PR TITLE
refactor: update document and invoice operations to use http_patch instead of http_post

### DIFF
--- a/moneysnake/document.py
+++ b/moneysnake/document.py
@@ -158,7 +158,7 @@ class Document(Synchronizable):
 
     def register_payment(self, payment: Payment) -> None:
         """Register a payment via the register_payment endpoint."""
-        data = http_post(
+        data = http_patch(
             f"{self._base_path()}/{self.id}/register_payment",
             data={"payment": payment.to_dict()},
         )

--- a/moneysnake/sales_invoice.py
+++ b/moneysnake/sales_invoice.py
@@ -191,7 +191,7 @@ class SalesInvoice(Synchronizable, CustomFieldModel):
         if email_message is not None:
             body["email_message"] = email_message
 
-        data = http_post(
+        data = http_patch(
             f"{self.endpoint}s/{self.id}/send_invoice",
             data={"sales_invoice_sending": body} if body else None,
         )
@@ -219,17 +219,17 @@ class SalesInvoice(Synchronizable, CustomFieldModel):
 
     def mark_as_dubious(self) -> None:
         """Mark the invoice as dubious."""
-        data = http_post(f"{self.endpoint}s/{self.id}/mark_as_dubious")
+        data = http_patch(f"{self.endpoint}s/{self.id}/mark_as_dubious")
         self.update(data)
 
     def mark_as_uncollectible(self) -> None:
         """Mark the invoice as uncollectible."""
-        data = http_post(f"{self.endpoint}s/{self.id}/mark_as_uncollectible")
+        data = http_patch(f"{self.endpoint}s/{self.id}/mark_as_uncollectible")
         self.update(data)
 
     def register_payment(self, payment: Payment) -> None:
         """Register a payment via the register_payment endpoint."""
-        data = http_post(
+        data = http_patch(
             f"{self.endpoint}s/{self.id}/register_payment",
             data={"payment": payment.to_dict()},
         )
@@ -237,7 +237,7 @@ class SalesInvoice(Synchronizable, CustomFieldModel):
 
     def duplicate_creditinvoice(self) -> "SalesInvoice":
         """Create a credit invoice for this invoice."""
-        data = http_post(f"{self.endpoint}s/{self.id}/duplicate_creditinvoice")
+        data = http_patch(f"{self.endpoint}s/{self.id}/duplicate_creditinvoice")
         return SalesInvoice(**data)
 
     # --- Lookup helpers ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "moneysnake"
-version = "0.5.0"
+version = "0.5.1"
 description = "Moneybird SDK for Python"
 authors = [{ name = "ArjanCodes" }]
 license = { text = "MIT" }

--- a/tests/test_purchase_invoice.py
+++ b/tests/test_purchase_invoice.py
@@ -171,13 +171,13 @@ def test_delete_payment(
 def test_register_payment(
     mocker: MockType, document_data: dict[str, Any], payment_data: dict[str, Any]
 ):
-    mock_post = mocker.patch("moneysnake.document.http_post")
-    mock_post.return_value = {**document_data, "state": "paid", "paid_at": "2026-04-27"}
+    mock_patch = mocker.patch("moneysnake.document.http_patch")
+    mock_patch.return_value = {**document_data, "state": "paid", "paid_at": "2026-04-27"}
     invoice = PurchaseInvoice(**document_data)
     invoice.register_payment(Payment(**payment_data))
     assert invoice.state == "paid"
     assert (
-        mock_post.call_args[0][0]
+        mock_patch.call_args[0][0]
         == "documents/purchase_invoices/480487019028416410/register_payment"
     )
 

--- a/tests/test_sales_invoice.py
+++ b/tests/test_sales_invoice.py
@@ -287,21 +287,21 @@ def test_delete_payment(
 
 
 def test_send_invoice(mocker: MockType, invoice_data: dict[str, Any]):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
-    mock_post.return_value = {**invoice_data, "state": "open", "sent_at": "2026-03-31"}
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
+    mock_patch.return_value = {**invoice_data, "state": "open", "sent_at": "2026-03-31"}
     invoice = SalesInvoice(**invoice_data)
     invoice.send_invoice(delivery_method="Email")
     assert invoice.state == "open"
-    call_data = mock_post.call_args[1]["data"]
+    call_data = mock_patch.call_args[1]["data"]
     assert call_data["sales_invoice_sending"]["delivery_method"] == "Email"
 
 
 def test_send_invoice_no_options(mocker: MockType, invoice_data: dict[str, Any]):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
-    mock_post.return_value = {**invoice_data, "state": "open"}
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
+    mock_patch.return_value = {**invoice_data, "state": "open"}
     invoice = SalesInvoice(**invoice_data)
     invoice.send_invoice()
-    assert mock_post.call_args[1]["data"] is None
+    assert mock_patch.call_args[1]["data"] is None
 
 
 def test_pause(mocker: MockType, invoice_data: dict[str, Any]):
@@ -322,25 +322,25 @@ def test_resume(mocker: MockType, invoice_data: dict[str, Any]):
 
 
 def test_mark_as_dubious(mocker: MockType, invoice_data: dict[str, Any]):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
-    mock_post.return_value = {**invoice_data, "marked_dubious_on": "2026-03-31"}
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
+    mock_patch.return_value = {**invoice_data, "marked_dubious_on": "2026-03-31"}
     invoice = SalesInvoice(**invoice_data)
     invoice.mark_as_dubious()
     assert invoice.marked_dubious_on == "2026-03-31"
 
 
 def test_mark_as_uncollectible(mocker: MockType, invoice_data: dict[str, Any]):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
-    mock_post.return_value = {**invoice_data, "marked_uncollectible_on": "2026-03-31"}
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
+    mock_patch.return_value = {**invoice_data, "marked_uncollectible_on": "2026-03-31"}
     invoice = SalesInvoice(**invoice_data)
     invoice.mark_as_uncollectible()
     assert invoice.marked_uncollectible_on == "2026-03-31"
 
 
 def test_duplicate_creditinvoice(mocker: MockType, invoice_data: dict[str, Any]):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
     credit_data = {**invoice_data, "id": "550000000000000999", "state": "draft"}
-    mock_post.return_value = credit_data
+    mock_patch.return_value = credit_data
     invoice = SalesInvoice(**invoice_data)
     credit = invoice.duplicate_creditinvoice()
     assert credit.id == 550000000000000999
@@ -350,8 +350,8 @@ def test_duplicate_creditinvoice(mocker: MockType, invoice_data: dict[str, Any])
 def test_register_payment(
     mocker: MockType, invoice_data: dict[str, Any], payment_data: dict[str, Any]
 ):
-    mock_post = mocker.patch("moneysnake.sales_invoice.http_post")
-    mock_post.return_value = {**invoice_data, "state": "paid", "paid_at": "2026-03-31"}
+    mock_patch = mocker.patch("moneysnake.sales_invoice.http_patch")
+    mock_patch.return_value = {**invoice_data, "state": "paid", "paid_at": "2026-03-31"}
     invoice = SalesInvoice(**invoice_data)
     invoice.register_payment(Payment(**payment_data))
     assert invoice.state == "paid"

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "moneysnake"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Update document and invoice operations to use http_patch instead of http_post